### PR TITLE
Enable local runs and bunch of fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .vscode/
 commandTable.js
 bundle.js
+main.js
 compiled/
 *DS_Store
 stocks/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ cal | Google Calendar | [https://calendar.google.com/calendar/r](https://calenda
 covid | UVA COVID-19 Tracker | [https://returntogrounds.virginia.edu/covid-tracker](https://returntogrounds.virginia.edu/covid-tracker)
 DEFAULT | Default - Google Search | [https://google.com/](https://google.com/)
 
+## Local server
+
+1. Run `npm install` to install dependencies.
+
+2. Run `npm run server`.
+
+3. Navigate to `http://localhost:3000/?search=SEARCH_TERM` to verify the server is running.
+
 ## Setup
 
 1. Open Chrome and click the three dots. Click `Settings` and scroll down to `Search Engines`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "babel src/ -d compiled/",
     "bundle": "rollup compiled/app.js -o bundle.js -f cjs --compact",
     "minify": "minify --mangle bundle.js -o main.js",
+    "server": "npm run build && npm run bundle && npm run minify && node server.js",
     "flow": "flow"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -10,7 +10,9 @@ router.get('/',function(req, res){
 
 app.use('/', router);
 app.use('/static', express.static(path.join(__dirname, 'static')));
-app.use('/lib', express.static(path.join(__dirname, 'lib')))
-app.listen(process.env.port || 3000);
+app.use('/main.js', express.static(path.join(__dirname, 'main.js')));
 
-console.log('Running at Port 3000');
+const port = process.env.port || 3000;
+app.listen(port);
+
+console.log('Running at Port ' + port);


### PR DESCRIPTION
This PR does a couple of things:
1. Add `npm run server` command to build and start a local server
2. Add to the readme steps to run it locally (using this command)
3. Improvement on logging of the port in `server.js`
4. Remove unused route in `server.js`, added missing route for `main.js`
5. Update `.gitignore` to ignore build result `main.js`

Should help a lot of people trying to use this, for example #3